### PR TITLE
Adding Swift SendListener events to fire in sending

### DIFF
--- a/src/Transport/SendgridTransport.php
+++ b/src/Transport/SendgridTransport.php
@@ -38,6 +38,7 @@ class SendgridTransport extends Transport
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {
+        $this->beforeSendPerformed($message);
         list($from, $fromName) = $this->getFromAddresses($message);
         $payload = $this->options;
         $data = [
@@ -58,7 +59,9 @@ class SendgridTransport extends Transport
         } else {
             $payload += ['body' => $data];
         }
-        return $this->client->post('https://api.sendgrid.com/api/mail.send.json', $payload);
+        $response = $this->client->post('https://api.sendgrid.com/api/mail.send.json', $payload);
+        $this->sendPerformed($message);
+        return $response;
     }
     /**
      * @param  $data


### PR DESCRIPTION
Made `SendgridTransport` send method to fire events in `Swift_Events_SendListener` so it is possible other plugins to modify the content of the message. (eg: I wanted to use [fedeisas/laravel-mail-css-inliner](https://github.com/fedeisas/laravel-mail-css-inliner) as a plugin to modify the message before sending it.)